### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 If Deep Blue could talk
 =======================
-[![Latest Version](https://pypip.in/version/deep-blue-talks/badge.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
-[![Downloads](https://pypip.in/download/deep-blue-talks/badge.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
-[![Supported Python Version](https://pypip.in/py_versions/deep-blue-talks/badge.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
-[![License](https://pypip.in/license/deep-blue-talks/badge.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
-[![Development Status](https://pypip.in/status/deep-blue-talks/badge.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
+[![Latest Version](https://img.shields.io/pypi/v/deep-blue-talks.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
+[![Downloads](https://img.shields.io/pypi/dm/deep-blue-talks.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
+[![Supported Python Version](https://img.shields.io/pypi/pyversions/deep-blue-talks.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
+[![License](https://img.shields.io/pypi/l/deep-blue-talks.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
+[![Development Status](https://img.shields.io/pypi/status/deep-blue-talks.svg)](https://pypi.python.org/pypi/deep-blue-talks/)
 
 With a GM mind provided by [Stockfish][stockfish].
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20deep-blue-talks))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `deep-blue-talks`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.